### PR TITLE
Improve touch event handling + back reporting

### DIFF
--- a/tart/api/tart.api
+++ b/tart/api/tart.api
@@ -352,13 +352,16 @@ public final class tart/legacy/Perfs {
 
 public final class tart/legacy/RealTouchMetrics : tart/legacy/TouchMetrics {
 	public fun <init> ()V
+	public fun getLastBackKeyEvent ()Lkotlin/Pair;
 	public fun getLastTouchUpEvent ()Lkotlin/Pair;
 	public final fun install ()V
+	public fun setLastBackKeyEvent (Lkotlin/Pair;)V
 	public fun setLastTouchUpEvent (Lkotlin/Pair;)V
 	public final fun uninstall ()V
 }
 
 public abstract interface class tart/legacy/TouchMetrics {
+	public abstract fun getLastBackKeyEvent ()Lkotlin/Pair;
 	public abstract fun getLastTouchUpEvent ()Lkotlin/Pair;
 }
 

--- a/tart/build.gradle.kts
+++ b/tart/build.gradle.kts
@@ -19,7 +19,7 @@ android {
     targetSdkVersion(30)
     versionCode = 1
     versionName = "1.0"
-    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    testInstrumentationRunner = "tart.test.utilities.TartTestInstrumentationRunner"
   }
 
   buildFeatures {

--- a/tart/src/androidTest/java/tart/test/utilities/TartTestInstrumentationRunner.kt
+++ b/tart/src/androidTest/java/tart/test/utilities/TartTestInstrumentationRunner.kt
@@ -1,0 +1,41 @@
+package tart.test.utilities
+
+import android.os.Bundle
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.base.DefaultFailureHandler
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.runner.AndroidJUnitRunner
+import radiography.Radiography
+import radiography.ViewStateRenderers.DefaultsIncludingPii
+
+class TartTestInstrumentationRunner : AndroidJUnitRunner() {
+
+  override fun onCreate(arguments: Bundle?) {
+    super.onCreate(arguments)
+    val defaultFailureHandler =
+      DefaultFailureHandler(InstrumentationRegistry.getInstrumentation().targetContext)
+    Espresso.setFailureHandler { error, viewMatcher ->
+      try {
+        defaultFailureHandler.handle(error, viewMatcher)
+      } catch (decoratedError: Throwable) {
+        val detailMessageField = Throwable::class.java.getDeclaredField("detailMessage")
+        val previouslyAccessible = detailMessageField.isAccessible
+        try {
+          detailMessageField.isAccessible = true
+          var message = (detailMessageField[decoratedError] as String?).orEmpty()
+
+          // Remove Espresso terrible view hierarchy rendering.
+          message = message.substringBefore("\nView Hierarchy:")
+
+          val hierarchy = Radiography.scan(viewStateRenderers = DefaultsIncludingPii)
+          // Notice the plural: there's one view hierarchy per window.
+          message += "\nView hierarchies:\n$hierarchy"
+          detailMessageField[decoratedError] = message
+        } finally {
+          detailMessageField.isAccessible = previouslyAccessible
+        }
+        throw decoratedError
+      }
+    }
+  }
+}

--- a/tart/src/main/java/tart/legacy/RealTouchMetrics.kt
+++ b/tart/src/main/java/tart/legacy/RealTouchMetrics.kt
@@ -3,40 +3,66 @@ package tart.legacy
 import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
+import android.view.KeyEvent
+import android.view.KeyEvent.KEYCODE_BACK
 import android.view.MotionEvent
 import curtains.Curtains
+import curtains.KeyEventInterceptor
 import curtains.OnRootViewAddedListener
 import curtains.TouchEventInterceptor
+import curtains.keyEventInterceptors
 import curtains.phoneWindow
 import curtains.touchEventInterceptors
+import curtains.windowAttachCount
 
 class RealTouchMetrics : TouchMetrics {
 
   override var lastTouchUpEvent: Pair<MotionEvent, Long>? = null
 
-  private val handler = Handler(Looper.getMainLooper())
+  override var lastBackKeyEvent: Pair<Long, Long>? = null
 
-  private val clearLastTouchUpEvent = Runnable {
-    lastTouchUpEvent = null
-  }
+  private val handler = Handler(Looper.getMainLooper())
 
   private val listener = OnRootViewAddedListener { view ->
     view.phoneWindow?.let { window ->
-      window.touchEventInterceptors += TouchEventInterceptor { motionEvent, dispatch ->
-        val isActionUp = motionEvent.action == MotionEvent.ACTION_UP
-        if (isActionUp) {
-          lastTouchUpEvent?.first?.recycle()
-          lastTouchUpEvent = MotionEvent.obtain(motionEvent) to SystemClock.uptimeMillis()
-          handler.removeCallbacks(clearLastTouchUpEvent)
+      if (view.windowAttachCount == 0) {
+        window.touchEventInterceptors += TouchEventInterceptor { motionEvent, dispatch ->
+          val isActionUp = motionEvent.action == MotionEvent.ACTION_UP
+          // Note: what if we get 2 taps in a single dispatch loop? Then we're simply posting the
+          // following: (recordTouch, onClick, clearTouch, recordTouch, onClick, clearTouch).
+          if (isActionUp) {
+            val touchUpCopy = MotionEvent.obtain(motionEvent) to SystemClock.uptimeMillis()
+            handler.post {
+              lastTouchUpEvent = touchUpCopy
+            }
+          }
+          val dispatchState = dispatch(motionEvent)
+          // Android posts onClick callbacks when it receives the up event. So here we leverage
+          // afterTouchEvent at which point the onClick has been posted, and by posting then we ensure
+          // we're clearing the event right after the onclick is handled.
+          if (isActionUp) {
+            handler.post {
+              lastTouchUpEvent?.first?.recycle()
+              lastTouchUpEvent = null
+            }
+          }
+          dispatchState
         }
-        val dispatchState = dispatch(motionEvent)
-        // Android posts onClick callbacks when it receives the up event. So here we leverage
-        // afterTouchEvent at which point the onClick has been posted, and by posting then we ensure
-        // we're clearing the event right after the onclick is handled.
-        if (isActionUp) {
-          handler.post(clearLastTouchUpEvent)
+        window.keyEventInterceptors += KeyEventInterceptor { keyEvent, dispatch ->
+          val isBackPressed = keyEvent.keyCode == KEYCODE_BACK &&
+            keyEvent.action == KeyEvent.ACTION_UP &&
+            !keyEvent.isCanceled
+
+          if (isBackPressed) {
+            val now = SystemClock.uptimeMillis()
+            lastBackKeyEvent = keyEvent.eventTime to now
+          }
+
+          val dispatchState = dispatch(keyEvent)
+          lastBackKeyEvent = null
+
+          dispatchState
         }
-        dispatchState
       }
     }
   }

--- a/tart/src/main/java/tart/legacy/TouchMetrics.kt
+++ b/tart/src/main/java/tart/legacy/TouchMetrics.kt
@@ -10,4 +10,11 @@ interface TouchMetrics {
    * delivered.
    */
   val lastTouchUpEvent: Pair<MotionEvent, Long>?
+
+  /**
+   * Returns a pair of [android.view.KeyEvent.getEventTime] and the uptime millis at which it was
+   * delivered, if called from the main thread while the BACK key event is being delivered
+   * (e.g. this is non null if called from within an onBackPressed() callback).
+   */
+  val lastBackKeyEvent: Pair<Long, Long>?
 }


### PR DESCRIPTION
This ensures the touch up event is not available prior to onclick firing, and also adds support for retrieving BACK press timing information.

Source: https://github.com/pyricau/architecture-components-samples/pull/1/files#diff-ca43966dd2be9c88e24c82b6ff0d2997f97f8930e70eaaf8fb9e47ace1a460d6